### PR TITLE
Fix merge_tpl output path

### DIFF
--- a/merge_tpl.sh
+++ b/merge_tpl.sh
@@ -1,19 +1,26 @@
 #!/bin/bash
 
-# Check if an argument is provided
-if [ $# -eq 0 ]; then
-    echo "Usage: $0 directory_path"
+# Check if at least one argument is provided
+if [ $# -lt 1 ]; then
+    echo "Usage: $0 directory_path [output_file]"
     exit 1
 fi
 
 # First argument is the directory containing the text files
 DIRECTORY="$1"
 
-# Define the output file
-OUTPUT_FILE="/Users/wes/Documents/GitHub/TPL_Repo/tpl_code.txt"
+# Determine the output file. If a second argument is provided use it,
+# otherwise place the file in the repository root next to this script.
+if [ -n "$2" ]; then
+    OUTPUT_FILE="$2"
+else
+    SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+    OUTPUT_FILE="$SCRIPT_DIR/tpl_code.txt"
+fi
 
-# Merge all text files in the directory into one
-cat "$DIRECTORY"/*.tpl >> "$OUTPUT_FILE"
+# Merge all text files in the directory into one, overwriting any
+# existing file
+cat "$DIRECTORY"/*.tpl > "$OUTPUT_FILE"
 
 echo "All files in $DIRECTORY merged into $OUTPUT_FILE"
 


### PR DESCRIPTION
## Summary
- make merge target path configurable at runtime
- default output to tpl_code.txt at repo root
- overwrite output file instead of appending

## Testing
- `shellcheck merge_tpl.sh`

------
https://chatgpt.com/codex/tasks/task_e_686d4708b4188326b103ffc6a0e01daf