### PR TITLE
Fix module name to traversys_ArchestrA

### DIFF
--- a/Software/traversys_ArchestrA.tpl
+++ b/Software/traversys_ArchestrA.tpl
@@ -1,4 +1,4 @@
-tpl 1.9 module traversys_OpenOffice;
+tpl 1.9 module traversys_ArchestrA;
 
 metadata
     origin := "Traversys";


### PR DESCRIPTION
## Summary
- fix the module declaration in `traversys_ArchestrA.tpl`

## Testing
- `git diff --cached --name-status`


------
https://chatgpt.com/codex/tasks/task_e_686d488cd2e483268d123e2ebc6e9e3b