### PR TITLE
Add credential encryption and storage to PsuedoVault

### DIFF
--- a/Extensions/traversys_DiscoAPI.tpl
+++ b/Extensions/traversys_DiscoAPI.tpl
@@ -54,7 +54,7 @@ pattern traversys_discoAPI 1.0
         username:= psuedoVault.username;
         configs:=search(PatternConfiguration where name = "PsuedoVault.psuedoVault");
         config:=configs[0];
-        password:= config._p;
+        password:= PsuedoVault.reveal(config._p);
         payload:= "grant_type=password&username=%username%&password=%password%";
         log.debug("payload=%payload%");
         token:= discovery.restfulPost(selfDS, "oauth2", "/api/token",payload);


### PR DESCRIPTION
## Summary
- add additional credentials configuration
- implement reversible obscuring functions
- store credentials in an encoded form
- decode stored credentials in DiscoAPI pattern

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686d494d0f7483268dd177bd326d3da4